### PR TITLE
Adding very basic support for Marathon HTTP auth

### DIFF
--- a/marathon/src/main/scala/io/buoyant/marathon/v2/Api.scala
+++ b/marathon/src/main/scala/io/buoyant/marathon/v2/Api.scala
@@ -117,8 +117,8 @@ object Api {
     }
   }
 
-  def apply(client: Client, uriPrefix: String, useHealthCheck: Boolean): Api =
-    new AppIdApi(client, s"$uriPrefix/$versionString", useHealthCheck)
+  def apply(client: Client, uriPrefix: String, useHealthCheck: Boolean, httpAuth: String): Api =
+    new AppIdApi(client, s"$uriPrefix/$versionString", useHealthCheck, httpAuth)
 
   private[v2] def rspToAppIds(rsp: http.Response): Future[Api.AppIds] =
     rsp.status match {
@@ -175,7 +175,7 @@ object Api {
     }
 }
 
-private class AppIdApi(client: Api.Client, apiPrefix: String, useHealthCheck: Boolean)
+private class AppIdApi(client: Api.Client, apiPrefix: String, useHealthCheck: Boolean, httpAuth: String)
   extends Api
   with Closable {
 
@@ -185,11 +185,13 @@ private class AppIdApi(client: Api.Client, apiPrefix: String, useHealthCheck: Bo
 
   def getAppIds(): Future[Api.AppIds] = {
     val req = http.Request(s"$apiPrefix/apps")
+    req.headerMap.add(http.Fields.Authorization, "Basic " + httpAuth)
     Trace.letClear(client(req)).flatMap(rspToAppIds)
   }
 
   def getAddrs(app: Path): Future[Set[Address]] = {
     val req = http.Request(s"$apiPrefix/apps${app.show}?embed=app.tasks")
+    req.headerMap.add(http.Fields.Authorization, "Basic " + httpAuth)
     Trace.letClear(client(req)).flatMap(rspToAddrs(_, useHealthCheck))
   }
 }

--- a/namer/marathon/src/main/scala/io/buoyant/namer/marathon/MarathonInitializer.scala
+++ b/namer/marathon/src/main/scala/io/buoyant/namer/marathon/MarathonInitializer.scala
@@ -100,7 +100,8 @@ case class MarathonConfig(
   dst: Option[String],
   uriPrefix: Option[String],
   ttlMs: Option[Int],
-  useHealthCheck: Option[Boolean]
+  useHealthCheck: Option[Boolean],
+  httpAuth: Option[String]
 ) extends NamerConfig {
   import MarathonConfig._
 
@@ -132,9 +133,10 @@ case class MarathonConfig(
         new Authenticator.Authenticated(client, auth)
     }
 
+    val httpAuth0 = httpAuth.getOrElse("")
     val uriPrefix0 = uriPrefix.getOrElse("")
     val useHealthCheck0 = useHealthCheck.getOrElse(false)
-    val api = Api(service, uriPrefix0, useHealthCheck0)
+    val api = Api(service, uriPrefix0, useHealthCheck0, httpAuth0)
 
     val ttl = ttlMs.getOrElse(5000).millis
     new AppIdNamer(api, prefix, ttl)


### PR DESCRIPTION
If httpAuth is not sent, the HTTP request to marathon
sends an empty Authorization header. Still works, but not
particularly clean.